### PR TITLE
Merchant items create

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -4,7 +4,7 @@ class MerchantItemsController < ApplicationController
   end
 
   def new
-
+    @merchant = Merchant.find(params[:id])
   end
 
   def show
@@ -15,6 +15,13 @@ class MerchantItemsController < ApplicationController
   def edit
     @merchant = Merchant.find(params[:id])
     @item = Item.find(params[:item_id])
+  end
+
+  def create
+    merchant = Merchant.find(params[:id])
+    merchant.items.create(name: params[:name], description: params[:description], unit_price: params[:unit_price])
+
+    redirect_to "/merchants/#{merchant.id}/items"
   end
 
   def update

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -1,6 +1,9 @@
 class MerchantItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:id])
+  end
+
+  def new
 
   end
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,7 +6,7 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
 
   validates_presence_of :name
-  
+
   # def ordered_items_to_ship
   #   item_ids = InvoiceItem.where("status = 0 OR status = 1").pluck(:item_id)
   #   item_ids.map do |id|
@@ -16,5 +16,9 @@ class Merchant < ApplicationRecord
 
   def ordered_items_to_ship
     Item.find_by_sql "SELECT items.name, invoice_items.invoice_id, invoice_items.status, invoice_items.created_at FROM items INNER JOIN invoice_items ON items.id=invoice_items.item_id WHERE status=0 OR status=1 ORDER BY invoice_items.created_at ASC"
+  end
+
+  def group_items_by_status(bool)
+    items.where("status = #{bool}")
   end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,7 +1,16 @@
 <h1> <%= @merchant.name %></h1>
 
-<% @merchant.items.each do |item| %>
-<a href="/merchants/<%=@merchant.id%>/items/<%=item.id%>"><h2><%= item.name %></h2></a>
-<h2>enabled: <%= item.status.to_s %></h2>
-<%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :change_status, params: {item_id: item.id} %>
+<h2 style="color: green;"> Enabled Items: </h2>
+<% @merchant.group_items_by_status(true).each do |en_item| %>
+  <a href="/merchants/<%=@merchant.id%>/items/<%=en_item.id%>"><h2><%= en_item.name %></h2></a>
+  <h2>enabled: <%= en_item.status.to_s %></h2>
+  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :change_status, params: {item_id: en_item.id} %>
+<% end %>
+
+
+<h2 style="color: red;"> Disabled Items: </h2>
+<% @merchant.group_items_by_status(false).each do |dis_item| %>
+  <a href="/merchants/<%=@merchant.id%>/items/<%=dis_item.id%>"><h2><%= dis_item.name %></h2></a>
+  <h2>enabled: <%= dis_item.status.to_s %></h2>
+  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :change_status, params: {item_id: dis_item.id} %>
 <% end %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,7 +1,6 @@
 <h1> <%= @merchant.name %></h1>
 
-<%= button_to "Create New Item", "/merchants/#{@merchant.id}/items/new", get: :new %>
-
+<%= button_to "Create New Item", "/merchants/#{@merchant.id}/items/new", method: :get%>
 
 <h2 style="color: green;"> Enabled Items: </h2>
 <% @merchant.group_items_by_status(true).each do |en_item| %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -6,7 +6,7 @@
 <% @merchant.group_items_by_status(true).each do |en_item| %>
   <a href="/merchants/<%=@merchant.id%>/items/<%=en_item.id%>"><h2><%= en_item.name %></h2></a>
   <h2>enabled: <%= en_item.status.to_s %></h2>
-  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :change_status, params: {item_id: en_item.id} %>
+  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :patch, params: {item_id: en_item.id}, action: "change_status"%>
 <% end %>
 
 
@@ -14,5 +14,5 @@
 <% @merchant.group_items_by_status(false).each do |dis_item| %>
   <a href="/merchants/<%=@merchant.id%>/items/<%=dis_item.id%>"><h2><%= dis_item.name %></h2></a>
   <h2>enabled: <%= dis_item.status.to_s %></h2>
-  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :change_status, params: {item_id: dis_item.id} %>
+  <%= button_to "Switch Status", "/merchants/#{@merchant.id}/items/", method: :patch, params: {item_id: dis_item.id}, action: "change_status" %>
 <% end %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,8 @@
 <h1> <%= @merchant.name %></h1>
 
+<%= button_to "Create New Item", "/merchants/#{@merchant.id}/items/new", get: :new %>
+
+
 <h2 style="color: green;"> Enabled Items: </h2>
 <% @merchant.group_items_by_status(true).each do |en_item| %>
   <a href="/merchants/<%=@merchant.id%>/items/<%=en_item.id%>"><h2><%= en_item.name %></h2></a>

--- a/app/views/merchant_items/new.html.erb
+++ b/app/views/merchant_items/new.html.erb
@@ -1,0 +1,12 @@
+<%= form_with url: "/merchants/#{@merchant.id}/items", method: 'POST', local: true do |form| %>
+  <%= form.label :name %> <br>
+  <%= form.text_field :name %><br><br>
+
+  <%= form.label :description %> <br>
+  <%= form.text_field :description %><br><br>
+
+  <%= form.label :unit_price %><br>
+  <%= form.text_field :unit_price %><br><br>
+
+  <%= form.submit "Create Item"%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     patch "/merchants/:id/invoices/:invoice_id", to: 'merchant_invoices#update'
 
     get "/merchants/:id/items" , to: 'merchant_items#index'
+    get "/merchants/:id/items/new", to: 'merchant_items#new'
     get "/merchants/:id/items/:item_id", to: 'merchant_items#show'
     get "/merchants/:id/items/:item_id/edit", to: 'merchant_items#edit'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
     get "/merchants/:id/items/:item_id", to: 'merchant_items#show'
     get "/merchants/:id/items/:item_id/edit", to: 'merchant_items#edit'
 
-    post '/merchants/:id/items' , to: 'merchant_items#change_status'
+    post '/merchants/:id/items' , to: 'merchant_items#create'
+    patch '/merchants/:id/items' , to: 'merchant_items#change_status'
     patch "/merchants/:id/items/:item_id", to: 'merchant_items#update'
 
     get '/merchants/:merchant_id/invoices', to: 'merchant_invoices#index'

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -27,7 +27,16 @@ RSpec.describe 'Merchant Items index page' do
     expect(page).to_not have_content(@item_2.name)
     expect(page).to have_content(@item_3.name)
     expect(page).to have_link("#{@item_3.name}", :href => "/merchants/#{@merchant_2.id}/items/#{@item_3.id}")
+  end
 
+  it 'shows link to create new item' do
+    visit "merchants/#{@merchant_1.id}/items"
+    expect(page).to have_button("Create New Item")
+  end
 
+  it 'properly links to new page' do
+    visit "merchants/#{@merchant_1.id}/items"
+    click_button("Create New Item")
+    expect(current_path).to eq("merchants/#{@merchant_1.id}/items/new")
   end
 end

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe 'Merchant Items index page' do
   it 'properly links to new page' do
     visit "merchants/#{@merchant_1.id}/items"
     click_button("Create New Item")
-    expect(current_path).to eq("merchants/#{@merchant_1.id}/items/new")
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/new")
   end
 end

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items New Page' do
+  before(:each) do
+    @merchant_1 = Merchant.create!(name: 'Schroeder-Jerde')
+    @merchant_2 = Merchant.create!(name: 'Cummings-Thiel')
+    @item_1 = @merchant_1.items.create!(name: 'tem Qui Esse', description: 'nihil autem', unit_price: 75107)
+    @item_2 = @merchant_1.items.create!(name: 'Item Autem Minima', description: 'Cumque consequuntu', unit_price: 67076)
+    @item_3 = @merchant_2.items.create!(name: 'Item Ea Voluptatum', description: 'Sunt officia', unit_price: 32301)
+  end
+
+  it 'has an empty form for a new item' do
+   visit "/merchants/#{@merchant_1.id}/items/new"
+
+   fill_in(:name, with: "Quiche")
+   fill_in(:description, with: 'Darn Good Quiche')
+   fill_in(:unit_price, with: "173")
+
+   click_button('Create Item')
+
+   expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+   expect(page).to have_content("Quiche")
+   expect(page).to have_content("Darn Good Quiche")
+   expect(page).to have_content("173")
+
+   visit "/merchants/#{@merchant_1.id}/items/new"
+
+   fill_in(:name, with: "Tomato Soup")
+   fill_in(:description, with: 'Does not come with grilled cheese')
+   fill_in(:unit_price, with: "200")
+
+   click_button('Create Item')
+
+   expect(current_path).to eq("/merchants/#{@merchant_2.id}/items")
+   expect(page).to have_content("Tomato Soup")
+   expect(page).to have_content("Does not come with grilled cheese")
+   expect(page).to have_content("200")
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -17,17 +17,16 @@ RSpec.describe Merchant, type: :model do
     merchant = create(:merchant)
     expect(merchant).to be_a(Merchant)
     expect(merchant).to be_valid
-  end 
+  end
 
-  # it 'lists items ready to ship' do
-  #   merchant = create(:merchant)
-  #   item1 = create(:item)
-  #   item2 = create(:item)
-  #   item3 = create(:item)
-  #   item4 = create(:item)
-  #   invoice_item1 = (:invoice_item, result: 0, item_id: item1.id)
-  #   invoice_item2 = (:invoice_item, result: 2, item_id: item2.id)
+  describe 'class methods' do 
+    it '::group_items_by_status(bool)' do
+      merchant = Merchant.create!(name: "Joe Schmoe's Lil Shoppe")
+      item = merchant.items.create!(name: "Plutonium", description: "Good ol' Plutonium brother! YEE YEE!", unit_price: 300, status: true)
+      item_two = merchant.items.create!(name: "Uranium", description: "Boring Uranium-235", unit_price: 150)
 
-  #   expect(merchant.ordered_items_to_ship).to eq([item1, item1, item3, item8, item5])
-  # end
+      expect(merchant.group_items_by_status(true)).to eq([merchant.items.find(item.id)])
+      expect(merchant.group_items_by_status(false)).to eq([merchant.items.find(item_two.id)])
+    end
+  end
 end


### PR DESCRIPTION
GitHub needs to fix their fucking site so that my pull requests automatically default to the specific fork I made the pull request on instead of to the base repository the fork is FORKED from - that being said, here's this stuff:

Relatively rough user story - something happened with my database where I had to reset the primary keys in-order to get the merchant_items#create method to start working (for future reference: https://stackoverflow.com/questions/47577532/why-pguniqueviolation-error-duplicate-key-value-violates-unique-constraint) - also updated the routes for merchant_items#change_status from post to patch since it's more accurate (also refer to my previous pull request on what to do about this method and it's integration into merchant_items#update instead), very very lovely project so far (i am in partial agony)